### PR TITLE
docs: replace single by double on quotes rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ const baz = "qux";
 const func = () => {};
 ```
 
-Always use single quotes or template literals
+Always use double quotes or template literals
 
 **✅ Good:**
 


### PR DESCRIPTION
The text specifies to use single quotes but the rule is to use double quotes.