### PR TITLE
[MASTER] - Documentação sobre prop spreading em componentes wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,7 +1036,7 @@ const MyComponent = (type) => {
 
 ### 7.8 Using spread operator
 
-When creating a component wrapper we can spread the types from our original component. That way the wrapper extends all the props from the original component automatically. Creating a custom type and passing on `React.FC` typescript can give us all the correct props. This is useful to avoid creating a custom interface for our wrapper with missing props from the original component.
+When creating a component wrapper we can spread the types from our original component. That way the wrapper extends all the props from the original component automatically. This is useful to avoid creating a custom interface for our wrapper with missing props from the original component.
 
 **✅ Good:**
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Use soft tabs with two spaces. You need to configure your editor for this.
 
 ```js
 const obj = {
-  prop: "value",
-  prop2: "value2",
-  prop3: "value3",
-}
+  prop: 'value',
+  prop2: 'value2',
+  prop3: 'value3',
+};
 ```
 
 ```css
@@ -74,21 +74,21 @@ const obj = {
 
 ```js
 const obj = {
-    prop: "value",
-    prop2: "value2",
-    prop3: "value3",
-}
+  prop: 'value',
+  prop2: 'value2',
+  prop3: 'value3',
+};
 ```
 
 ```css
 .foo {
-    color: red;
+  color: red;
 }
 ```
 
 ```html
 <div>
-    <p>Hello World</p>
+  <p>Hello World</p>
 </div>
 ```
 
@@ -97,12 +97,13 @@ const obj = {
 Refactoring makes part of JSMLover's way of being, doing it every day and task by task. We have good practices and conditions to do that, though.
 
 ```js
-if(!isWholeCodeCoveraged) return
+if (!isWholeCodeCoveraged) return;
 ```
-- We can only refactor codes that have tests (and that tests!), which means 100% coverage! This way, we can improve or code safely. 
 
-- Keep the current tests and make them pass! 
-Once the current code is tested and can be refactored. We must make sure that the new changes will not break the current tests. 
+- We can only refactor codes that have tests (and that tests!), which means 100% coverage! This way, we can improve or code safely.
+
+- Keep the current tests and make them pass!
+  Once the current code is tested and can be refactored. We must make sure that the new changes will not break the current tests.
 
 ## 2. Architecture
 
@@ -172,7 +173,7 @@ For example:
 ┣ ┣ ┃ ┃ ┣ 📜 UserProfile.stories.mdx \
 ```
 
-#### Scoped Files 
+#### Scoped Files
 
 We need to add inside `pages/**/{utils, helpers, context, hooks, etc...}` and use `camelCase` as **Naming Convention**.
 
@@ -589,9 +590,9 @@ Never use semicolons.
 **✅ Good:**
 
 ```js
-const foo = 'bar'
-const baz = 'qux'
-const func = () => {}
+const foo = 'bar';
+const baz = 'qux';
+const func = () => {};
 ```
 
 **❌ Bad:**
@@ -607,15 +608,15 @@ Always use single quotes or template literals
 **✅ Good:**
 
 ```js
-const string = 'foo'
-const template = `foo`
+const string = 'foo';
+const template = `foo`;
 ```
 
 **❌ Bad:**
 
 ```js
-const string = "foo"
-const template = "foo"
+const string = 'foo';
+const template = 'foo';
 ```
 
 <a name="variables"></a>
@@ -626,7 +627,7 @@ For strict equality checks `===` should be used in favor of `==`.
 
 ```js
 if (foo === 'foo') {
-  statement
+  statement;
 }
 ```
 
@@ -634,7 +635,7 @@ if (foo === 'foo') {
 
 ```js
 if (foo == 'foo') {
-  statement
+  statement;
 }
 ```
 
@@ -645,13 +646,13 @@ Use meaningful, pronounceable, and in **English** variable names.
 **✅ Good:**
 
 ```js
-const currentDate = new Date().toLocaleDateString('pt-BR')
+const currentDate = new Date().toLocaleDateString('pt-BR');
 ```
 
 **❌ Bad:**
 
 ```js
-const xpto = new Date().toLocaleDateString('pt-BR')
+const xpto = new Date().toLocaleDateString('pt-BR');
 ```
 
 <a name="descriptive-validations"></a>
@@ -663,7 +664,7 @@ Creating const to describe validations.
 **✅ Good:**
 
 ```js
-const hasFullUserName = user.firstName && user.lastname
+const hasFullUserName = user.firstName && user.lastname;
 
 if (hasFullUserName) {
   //do awesome something
@@ -693,13 +694,13 @@ const messagingChannels = {
   },
   email: (message) => {
     // send message to email
-  }
-}
+  },
+};
 
 const sendMessage = (message, channel) => {
   const send = messagingChannels[channel];
   return send && send(message);
-}
+};
 ```
 
 **❌ Bad:**
@@ -707,19 +708,19 @@ const sendMessage = (message, channel) => {
 ```js
 const sendWhatsapp = (message) => {
   // send message to whatsapp
-}
+};
 
 const sendEmail = (message) => {
   // send message to email
-}
+};
 
 const sendMessage = (message, channel) => {
   if (channel === 'whatsapp') {
-    sendWhatsapp(message)
+    sendWhatsapp(message);
   } else if (channel === 'email') {
-    sendEmail(message)
+    sendEmail(message);
   }
-}
+};
 ```
 
 ### 6.5 Code Comments
@@ -729,26 +730,27 @@ Avoid writing comments to explain the code. Use comments to answer “Why?” in
 **✅ Good:**
 
 ```js
-  const TIME_IN_SECONDS = 60 * 40 // 40 minutes
+const TIME_IN_SECONDS = 60 * 40; // 40 minutes
 
-  // xxxx@xxxx.xxx
-  const regex = /^[a-z0-9.]+@[a-z0-9]+\.[a-z]+\.([a-z]+)?$/i
+// xxxx@xxxx.xxx
+const regex = /^[a-z0-9.]+@[a-z0-9]+\.[a-z]+\.([a-z]+)?$/i;
 
-  const calculateProductsPrice = () => {
-    // do something
-  }
+const calculateProductsPrice = () => {
+  // do something
+};
 ```
 
 **❌ Bad:**
 
 ```js
-  // This coolFunction calculates the prices of the products
-  const coolFunction = () => {
-    // do something
-  }
+// This coolFunction calculates the prices of the products
+const coolFunction = () => {
+  // do something
+};
 ```
 
 <a name="errors-destructuring"></a>
+
 ### 6.6 Avoid errors while destructuring
 
 Its a common mistake destructuring while the object is null or undefined, the destructuring will throw an error.
@@ -756,27 +758,26 @@ Its a common mistake destructuring while the object is null or undefined, the de
 **✅ Good:**
 
 ```js
-  const { age } = { ...null } // undefined
-  const { age } = null || {} // undefined
+const { age } = { ...null }; // undefined
+const { age } = null || {}; // undefined
 
-  // other values won't throw an error
-  const { emptyString } = '';
-  const { nan } = NaN;
-  const { emptyObject } = {};
+// other values won't throw an error
+const { emptyString } = '';
+const { nan } = NaN;
+const { emptyObject } = {};
 
-  function foo(bar = {}) {
-    const { age } = bar;
-  }
-  
-  foo() // undefined
-  
+function foo(bar = {}) {
+  const { age } = bar;
+}
+
+foo(); // undefined
 ```
 
 **❌ Bad:**
 
 ```js
-  const { age } = null // will throw an typeError
-  const { age } = undefined // will throw an typeError
+const { age } = null; // will throw an typeError
+const { age } = undefined; // will throw an typeError
 ```
 
 **[⬆ back to summary](#-summary)**
@@ -818,7 +819,7 @@ If the new state is calculated using the previous state, you can pass a function
 **✅ Good:**
 
 ```js
-const [number, setNumber] = useState(1)
+const [number, setNumber] = useState(1);
 
 return (
   <div>
@@ -830,7 +831,7 @@ return (
       Decrease
     </button>
   </div>
-)
+);
 ```
 
 **❌ Bad:**
@@ -854,12 +855,12 @@ Use the useEffect dependency array to trigger side effects, and make your code c
 **✅ Good:**
 
 ```js
-const [page, setPage] = useState(1)
+const [page, setPage] = useState(1);
 
 useEffect(() => {
-  requestListUser()
+  requestListUser();
   // calls useEffect when page state changes
-}, [page])
+}, [page]);
 
 return (
   <div>
@@ -867,29 +868,29 @@ return (
       Next Page
     </button>
   </div>
-)
+);
 ```
 
 **❌ Bad:**
 
 ```js
-const [page, setPage] = useState(1)
+const [page, setPage] = useState(1);
 
 useEffect(() => {
-  requestListUser()
-}, [])
+  requestListUser();
+}, []);
 
 const requestListUser = () => {
-  setPage((prevState) => prevState + 1)
+  setPage((prevState) => prevState + 1);
   // ...
   // any code to return user list
-}
+};
 
 return (
   <div>
     <button onClick={() => requestListUser()}>Next Page</button>
   </div>
-)
+);
 ```
 
 ### 7.4 Readable components
@@ -915,7 +916,7 @@ const Screen = () => (
       </List>
     </Main>
   </Container>
-)
+);
 ```
 
 **❌ Bad:**
@@ -937,7 +938,7 @@ const Screen = () => (
       </Box>
     </Box>
   </Box>
-)
+);
 ```
 
 ### 7.5 Styled Component Naming Convention
@@ -948,16 +949,16 @@ Use PascalCase as a convention in styled-components
 
 ```js
 export const CustomText = styled.p`
-  color: 'red'
-`
+  color: 'red';
+`;
 ```
 
 **❌ Bad:**
 
 ```js
 export const customText = styled.p`
-  color: 'red'
-`
+  color: 'red';
+`;
 ```
 
 ### 7.6 Using Styled Component in React Components
@@ -967,34 +968,23 @@ Import Styled Component as `S`
 **✅ Good:**
 
 ```tsx
-import * as S from './styles'
+import * as S from './styles';
 
-const MyComponent = () => (
-  <S.CustomText>
-    text example
-  </S.CustomText>
-)
+const MyComponent = () => <S.CustomText>text example</S.CustomText>;
 ```
 
 **❌ Bad:**
 
 ```tsx
-import * as Style from './styles'
+import * as Style from './styles';
 
 const MyComponent = () => (
-  <Style.CustomText>
-    text example
-  </Style.CustomText>
-)
+  <Style.CustomText>text example</Style.CustomText>
+);
 
+import { CustomText } from './styles';
 
-import { CustomText } from './styles'
-
-const MyComponent = () => (
-  <CustomText>
-    text example
-  </CustomText>
-)
+const MyComponent = () => <CustomText>text example</CustomText>;
 ```
 
 ### 7.7 Avoid compare directly strings
@@ -1007,31 +997,91 @@ When know all possible values we can use enum to achieve better readability and 
 const FEEDBACK = {
   CORRECT: 'correct',
   INCORRECT: 'incorrect',
-}
+};
 
 const MyComponent = (type) => {
-  const text = type === FEEDBACK.CORRECT ? '😎' : '😢'
-  
-  return (
-    <Emoji>
-      {text}
-    </Emoji>
-  )
-}
+  const text = type === FEEDBACK.CORRECT ? '😎' : '😢';
+
+  return <Emoji>{text}</Emoji>;
+};
 ```
 
 **❌ Bad:**
 
 ```tsx
 const MyComponent = (type) => {
-  const text = type === 'correct' ? '😎' : '😢'
+  const text = type === 'correct' ? '😎' : '😢';
 
+  return <Emoji>{text}</Emoji>;
+};
+```
+
+### 7.7 Using spread operator
+
+When creating a component wrapper we can spread the types from our original component. That way the wrapper extends all the props from the original component automatically. Creating a custom type and passing on `React.FC` typescript can give us all the correct props. This is usefull to avoid creating a custom interface for our wrapper with missing props from the original component.
+
+**✅ Good:**
+
+```tsx
+import { MenuItem, TextField } from '@mui/material';
+import { TextFieldProps } from '@mui/material';
+
+export type SelectOption = { value: string; label: string };
+
+export type SelectProps = TextFieldProps & {
+  options: SelectOption[];
+};
+
+const Select: React.FC<SelectProps> = ({ options, ...props }) => {
   return (
-    <Emoji>
-      {text}
-    </Emoji>
-  )
-}
+    <TextField {...props}>
+      {options.map((option) => (
+        <MenuItem key={uuidv4()} value={option.value}>
+          {option.label}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+};
+```
+
+**❌ Bad:**
+
+```tsx
+import { MenuItem, TextField } from '@mui/material';
+
+export type SelectOption = { value: string; label: string };
+
+export type SelectProps = {
+  options: SelectOption[];
+  disabled: boolean;
+  onChange: () => void;
+  value: string;
+  onBlur: () => void;
+};
+
+const Select: React.FC<SelectProps> = ({
+  options,
+  disabled,
+  onChange,
+  value,
+  onBlur,
+}) => {
+  return (
+    <TextField
+      disabled={disabled}
+      onChange={handleOnChange}
+      value={value}
+      onBlur={handleOnBlur}
+    >
+      {options.map((option) => (
+        <MenuItem key={uuidv4()} value={option.value}>
+          {option.label}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+};
 ```
 
 **[⬆ back to summary](#-summary)**
@@ -1104,7 +1154,7 @@ This prevents conflicts with existing and future HTML elements, since all HTML e
 export default {
   name: 'TodoItem',
   // ...
-}
+};
 ```
 
 **❌ Bad:**
@@ -1113,7 +1163,7 @@ export default {
 export default {
   name: 'Todo',
   // ...
-}
+};
 ```
 
 ### 8.4 Prop definitions
@@ -1126,19 +1176,19 @@ In committed code, prop definitions should always be as detailed as possible, sp
 export default {
   status: {
     type: String,
-    required: true
-  }
+    required: true,
+  },
   // ...
-}
+};
 ```
 
 **❌ Bad:**
 
 ```js
 export default {
-  props: ['status']
+  props: ['status'],
   // ...
-}
+};
 ```
 
 ### 8.5 Vue property decorator
@@ -1229,14 +1279,14 @@ To define the `test-id` to a component use the follow structure: `[page-name||co
 
 **✅ Good:**
 
-- forgot-password__input--email
-- header__select--cnpjList
-- login__button--forgot-password
+- forgot-password\_\_input--email
+- header\_\_select--cnpjList
+- login\_\_button--forgot-password
 
 **❌ Bad:**
 
 - forgot-email-input
-- header__cnpjList
+- header\_\_cnpjList
 - button--forgot-password
 
 ### 10.3 Selecting component
@@ -1248,7 +1298,9 @@ To select a component in order to test a behavior of to trigger any event we mus
 ```js
 describe('yourModule', () => {
   it('should do trigger click event', () => {
-    const button = wrapper.find('[data-testid="login__button--forgot-password"]')
+    const button = wrapper.find(
+      '[data-testid="login__button--forgot-password"]'
+    );
   });
 });
 ```
@@ -1258,7 +1310,7 @@ describe('yourModule', () => {
 ```js
 describe('yourModule', () => {
   it('should do trigger click event', () => {
-    const button = wrapper.find('button.btn-primary')
+    const button = wrapper.find('button.btn-primary');
   });
 });
 ```
@@ -1303,18 +1355,18 @@ For convention, use PascalCase for type names.
 
 ```ts
 type MyBeautifulType = {
-  name: string
-  age: number
-}
+  name: string;
+  age: number;
+};
 ```
 
 **❌ Bad:**
 
 ```ts
 type myBeautifulType = {
-  name: string
-  age: number
-}
+  name: string;
+  age: number;
+};
 ```
 
 ### 11.3 Exporting types
@@ -1331,9 +1383,9 @@ Within a file, type definitions should come first.
 // imports...
 
 type MyBeautifulType = {
-  name: string
-  age: number
-}
+  name: string;
+  age: number;
+};
 
 // rest of the file...
 ```
@@ -1346,9 +1398,9 @@ type MyBeautifulType = {
 // part of the file...
 
 type MyBeautifulType = {
-  name: string
-  age: number
-}
+  name: string;
+  age: number;
+};
 
 // rest of the file...
 ```
@@ -1361,9 +1413,9 @@ Create a type for increase legible
 
 ```ts
 type PersonType = {
-  name: string
-  age: number
-  birthDate: string
+  name: string;
+  age: number;
+  birthDate: string;
 };
 
 const Person = ({ name, age, birthDate }: PersonType) => {
@@ -1379,9 +1431,9 @@ const Person = ({
   age,
   birthDate,
 }: {
-  name: string,
-  age: number,
-  birthDate: string,
+  name: string;
+  age: number;
+  birthDate: string;
 }) => {
   // ...
 };

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Use soft tabs with two spaces. You need to configure your editor for this.
 
 ```js
 const obj = {
-  prop: 'value',
-  prop2: 'value2',
-  prop3: 'value3',
-};
+  prop: "value",
+  prop2: "value2",
+  prop3: "value3",
+}
 ```
 
 ```css
@@ -74,21 +74,21 @@ const obj = {
 
 ```js
 const obj = {
-  prop: 'value',
-  prop2: 'value2',
-  prop3: 'value3',
-};
+    prop: "value",
+    prop2: "value2",
+    prop3: "value3",
+}
 ```
 
 ```css
 .foo {
-  color: red;
+    color: red;
 }
 ```
 
 ```html
 <div>
-  <p>Hello World</p>
+    <p>Hello World</p>
 </div>
 ```
 
@@ -97,13 +97,12 @@ const obj = {
 Refactoring makes part of JSMLover's way of being, doing it every day and task by task. We have good practices and conditions to do that, though.
 
 ```js
-if (!isWholeCodeCoveraged) return;
+if(!isWholeCodeCoveraged) return
 ```
+- We can only refactor codes that have tests (and that tests!), which means 100% coverage! This way, we can improve or code safely. 
 
-- We can only refactor codes that have tests (and that tests!), which means 100% coverage! This way, we can improve or code safely.
-
-- Keep the current tests and make them pass!
-  Once the current code is tested and can be refactored. We must make sure that the new changes will not break the current tests.
+- Keep the current tests and make them pass! 
+Once the current code is tested and can be refactored. We must make sure that the new changes will not break the current tests. 
 
 ## 2. Architecture
 
@@ -173,7 +172,7 @@ For example:
 ┣ ┣ ┃ ┃ ┣ 📜 UserProfile.stories.mdx \
 ```
 
-#### Scoped Files
+#### Scoped Files 
 
 We need to add inside `pages/**/{utils, helpers, context, hooks, etc...}` and use `camelCase` as **Naming Convention**.
 
@@ -590,9 +589,9 @@ Never use semicolons.
 **✅ Good:**
 
 ```js
-const foo = 'bar';
-const baz = 'qux';
-const func = () => {};
+const foo = 'bar'
+const baz = 'qux'
+const func = () => {}
 ```
 
 **❌ Bad:**
@@ -608,15 +607,15 @@ Always use single quotes or template literals
 **✅ Good:**
 
 ```js
-const string = 'foo';
-const template = `foo`;
+const string = 'foo'
+const template = `foo`
 ```
 
 **❌ Bad:**
 
 ```js
-const string = 'foo';
-const template = 'foo';
+const string = "foo"
+const template = "foo"
 ```
 
 <a name="variables"></a>
@@ -627,7 +626,7 @@ For strict equality checks `===` should be used in favor of `==`.
 
 ```js
 if (foo === 'foo') {
-  statement;
+  statement
 }
 ```
 
@@ -635,7 +634,7 @@ if (foo === 'foo') {
 
 ```js
 if (foo == 'foo') {
-  statement;
+  statement
 }
 ```
 
@@ -646,13 +645,13 @@ Use meaningful, pronounceable, and in **English** variable names.
 **✅ Good:**
 
 ```js
-const currentDate = new Date().toLocaleDateString('pt-BR');
+const currentDate = new Date().toLocaleDateString('pt-BR')
 ```
 
 **❌ Bad:**
 
 ```js
-const xpto = new Date().toLocaleDateString('pt-BR');
+const xpto = new Date().toLocaleDateString('pt-BR')
 ```
 
 <a name="descriptive-validations"></a>
@@ -664,7 +663,7 @@ Creating const to describe validations.
 **✅ Good:**
 
 ```js
-const hasFullUserName = user.firstName && user.lastname;
+const hasFullUserName = user.firstName && user.lastname
 
 if (hasFullUserName) {
   //do awesome something
@@ -694,13 +693,13 @@ const messagingChannels = {
   },
   email: (message) => {
     // send message to email
-  },
-};
+  }
+}
 
 const sendMessage = (message, channel) => {
   const send = messagingChannels[channel];
   return send && send(message);
-};
+}
 ```
 
 **❌ Bad:**
@@ -708,19 +707,19 @@ const sendMessage = (message, channel) => {
 ```js
 const sendWhatsapp = (message) => {
   // send message to whatsapp
-};
+}
 
 const sendEmail = (message) => {
   // send message to email
-};
+}
 
 const sendMessage = (message, channel) => {
   if (channel === 'whatsapp') {
-    sendWhatsapp(message);
+    sendWhatsapp(message)
   } else if (channel === 'email') {
-    sendEmail(message);
+    sendEmail(message)
   }
-};
+}
 ```
 
 ### 6.5 Code Comments
@@ -730,27 +729,26 @@ Avoid writing comments to explain the code. Use comments to answer “Why?” in
 **✅ Good:**
 
 ```js
-const TIME_IN_SECONDS = 60 * 40; // 40 minutes
+  const TIME_IN_SECONDS = 60 * 40 // 40 minutes
 
-// xxxx@xxxx.xxx
-const regex = /^[a-z0-9.]+@[a-z0-9]+\.[a-z]+\.([a-z]+)?$/i;
+  // xxxx@xxxx.xxx
+  const regex = /^[a-z0-9.]+@[a-z0-9]+\.[a-z]+\.([a-z]+)?$/i
 
-const calculateProductsPrice = () => {
-  // do something
-};
+  const calculateProductsPrice = () => {
+    // do something
+  }
 ```
 
 **❌ Bad:**
 
 ```js
-// This coolFunction calculates the prices of the products
-const coolFunction = () => {
-  // do something
-};
+  // This coolFunction calculates the prices of the products
+  const coolFunction = () => {
+    // do something
+  }
 ```
 
 <a name="errors-destructuring"></a>
-
 ### 6.6 Avoid errors while destructuring
 
 Its a common mistake destructuring while the object is null or undefined, the destructuring will throw an error.
@@ -758,26 +756,27 @@ Its a common mistake destructuring while the object is null or undefined, the de
 **✅ Good:**
 
 ```js
-const { age } = { ...null }; // undefined
-const { age } = null || {}; // undefined
+  const { age } = { ...null } // undefined
+  const { age } = null || {} // undefined
 
-// other values won't throw an error
-const { emptyString } = '';
-const { nan } = NaN;
-const { emptyObject } = {};
+  // other values won't throw an error
+  const { emptyString } = '';
+  const { nan } = NaN;
+  const { emptyObject } = {};
 
-function foo(bar = {}) {
-  const { age } = bar;
-}
-
-foo(); // undefined
+  function foo(bar = {}) {
+    const { age } = bar;
+  }
+  
+  foo() // undefined
+  
 ```
 
 **❌ Bad:**
 
 ```js
-const { age } = null; // will throw an typeError
-const { age } = undefined; // will throw an typeError
+  const { age } = null // will throw an typeError
+  const { age } = undefined // will throw an typeError
 ```
 
 **[⬆ back to summary](#-summary)**
@@ -819,7 +818,7 @@ If the new state is calculated using the previous state, you can pass a function
 **✅ Good:**
 
 ```js
-const [number, setNumber] = useState(1);
+const [number, setNumber] = useState(1)
 
 return (
   <div>
@@ -831,7 +830,7 @@ return (
       Decrease
     </button>
   </div>
-);
+)
 ```
 
 **❌ Bad:**
@@ -855,12 +854,12 @@ Use the useEffect dependency array to trigger side effects, and make your code c
 **✅ Good:**
 
 ```js
-const [page, setPage] = useState(1);
+const [page, setPage] = useState(1)
 
 useEffect(() => {
-  requestListUser();
+  requestListUser()
   // calls useEffect when page state changes
-}, [page]);
+}, [page])
 
 return (
   <div>
@@ -868,29 +867,29 @@ return (
       Next Page
     </button>
   </div>
-);
+)
 ```
 
 **❌ Bad:**
 
 ```js
-const [page, setPage] = useState(1);
+const [page, setPage] = useState(1)
 
 useEffect(() => {
-  requestListUser();
-}, []);
+  requestListUser()
+}, [])
 
 const requestListUser = () => {
-  setPage((prevState) => prevState + 1);
+  setPage((prevState) => prevState + 1)
   // ...
   // any code to return user list
-};
+}
 
 return (
   <div>
     <button onClick={() => requestListUser()}>Next Page</button>
   </div>
-);
+)
 ```
 
 ### 7.4 Readable components
@@ -916,7 +915,7 @@ const Screen = () => (
       </List>
     </Main>
   </Container>
-);
+)
 ```
 
 **❌ Bad:**
@@ -938,7 +937,7 @@ const Screen = () => (
       </Box>
     </Box>
   </Box>
-);
+)
 ```
 
 ### 7.5 Styled Component Naming Convention
@@ -949,16 +948,16 @@ Use PascalCase as a convention in styled-components
 
 ```js
 export const CustomText = styled.p`
-  color: 'red';
-`;
+  color: 'red'
+`
 ```
 
 **❌ Bad:**
 
 ```js
 export const customText = styled.p`
-  color: 'red';
-`;
+  color: 'red'
+`
 ```
 
 ### 7.6 Using Styled Component in React Components
@@ -968,23 +967,34 @@ Import Styled Component as `S`
 **✅ Good:**
 
 ```tsx
-import * as S from './styles';
+import * as S from './styles'
 
-const MyComponent = () => <S.CustomText>text example</S.CustomText>;
+const MyComponent = () => (
+  <S.CustomText>
+    text example
+  </S.CustomText>
+)
 ```
 
 **❌ Bad:**
 
 ```tsx
-import * as Style from './styles';
+import * as Style from './styles'
 
 const MyComponent = () => (
-  <Style.CustomText>text example</Style.CustomText>
-);
+  <Style.CustomText>
+    text example
+  </Style.CustomText>
+)
 
-import { CustomText } from './styles';
 
-const MyComponent = () => <CustomText>text example</CustomText>;
+import { CustomText } from './styles'
+
+const MyComponent = () => (
+  <CustomText>
+    text example
+  </CustomText>
+)
 ```
 
 ### 7.7 Avoid compare directly strings
@@ -997,91 +1007,31 @@ When know all possible values we can use enum to achieve better readability and 
 const FEEDBACK = {
   CORRECT: 'correct',
   INCORRECT: 'incorrect',
-};
+}
 
 const MyComponent = (type) => {
-  const text = type === FEEDBACK.CORRECT ? '😎' : '😢';
-
-  return <Emoji>{text}</Emoji>;
-};
+  const text = type === FEEDBACK.CORRECT ? '😎' : '😢'
+  
+  return (
+    <Emoji>
+      {text}
+    </Emoji>
+  )
+}
 ```
 
 **❌ Bad:**
 
 ```tsx
 const MyComponent = (type) => {
-  const text = type === 'correct' ? '😎' : '😢';
+  const text = type === 'correct' ? '😎' : '😢'
 
-  return <Emoji>{text}</Emoji>;
-};
-```
-
-### 7.7 Using spread operator
-
-When creating a component wrapper we can spread the types from our original component. That way the wrapper extends all the props from the original component automatically. Creating a custom type and passing on `React.FC` typescript can give us all the correct props. This is usefull to avoid creating a custom interface for our wrapper with missing props from the original component.
-
-**✅ Good:**
-
-```tsx
-import { MenuItem, TextField } from '@mui/material';
-import { TextFieldProps } from '@mui/material';
-
-export type SelectOption = { value: string; label: string };
-
-export type SelectProps = TextFieldProps & {
-  options: SelectOption[];
-};
-
-const Select: React.FC<SelectProps> = ({ options, ...props }) => {
   return (
-    <TextField {...props}>
-      {options.map((option) => (
-        <MenuItem key={uuidv4()} value={option.value}>
-          {option.label}
-        </MenuItem>
-      ))}
-    </TextField>
-  );
-};
-```
-
-**❌ Bad:**
-
-```tsx
-import { MenuItem, TextField } from '@mui/material';
-
-export type SelectOption = { value: string; label: string };
-
-export type SelectProps = {
-  options: SelectOption[];
-  disabled: boolean;
-  onChange: () => void;
-  value: string;
-  onBlur: () => void;
-};
-
-const Select: React.FC<SelectProps> = ({
-  options,
-  disabled,
-  onChange,
-  value,
-  onBlur,
-}) => {
-  return (
-    <TextField
-      disabled={disabled}
-      onChange={handleOnChange}
-      value={value}
-      onBlur={handleOnBlur}
-    >
-      {options.map((option) => (
-        <MenuItem key={uuidv4()} value={option.value}>
-          {option.label}
-        </MenuItem>
-      ))}
-    </TextField>
-  );
-};
+    <Emoji>
+      {text}
+    </Emoji>
+  )
+}
 ```
 
 **[⬆ back to summary](#-summary)**
@@ -1154,7 +1104,7 @@ This prevents conflicts with existing and future HTML elements, since all HTML e
 export default {
   name: 'TodoItem',
   // ...
-};
+}
 ```
 
 **❌ Bad:**
@@ -1163,7 +1113,7 @@ export default {
 export default {
   name: 'Todo',
   // ...
-};
+}
 ```
 
 ### 8.4 Prop definitions
@@ -1176,19 +1126,19 @@ In committed code, prop definitions should always be as detailed as possible, sp
 export default {
   status: {
     type: String,
-    required: true,
-  },
+    required: true
+  }
   // ...
-};
+}
 ```
 
 **❌ Bad:**
 
 ```js
 export default {
-  props: ['status'],
+  props: ['status']
   // ...
-};
+}
 ```
 
 ### 8.5 Vue property decorator
@@ -1279,14 +1229,14 @@ To define the `test-id` to a component use the follow structure: `[page-name||co
 
 **✅ Good:**
 
-- forgot-password\_\_input--email
-- header\_\_select--cnpjList
-- login\_\_button--forgot-password
+- forgot-password__input--email
+- header__select--cnpjList
+- login__button--forgot-password
 
 **❌ Bad:**
 
 - forgot-email-input
-- header\_\_cnpjList
+- header__cnpjList
 - button--forgot-password
 
 ### 10.3 Selecting component
@@ -1298,9 +1248,7 @@ To select a component in order to test a behavior of to trigger any event we mus
 ```js
 describe('yourModule', () => {
   it('should do trigger click event', () => {
-    const button = wrapper.find(
-      '[data-testid="login__button--forgot-password"]'
-    );
+    const button = wrapper.find('[data-testid="login__button--forgot-password"]')
   });
 });
 ```
@@ -1310,7 +1258,7 @@ describe('yourModule', () => {
 ```js
 describe('yourModule', () => {
   it('should do trigger click event', () => {
-    const button = wrapper.find('button.btn-primary');
+    const button = wrapper.find('button.btn-primary')
   });
 });
 ```
@@ -1355,18 +1303,18 @@ For convention, use PascalCase for type names.
 
 ```ts
 type MyBeautifulType = {
-  name: string;
-  age: number;
-};
+  name: string
+  age: number
+}
 ```
 
 **❌ Bad:**
 
 ```ts
 type myBeautifulType = {
-  name: string;
-  age: number;
-};
+  name: string
+  age: number
+}
 ```
 
 ### 11.3 Exporting types
@@ -1383,9 +1331,9 @@ Within a file, type definitions should come first.
 // imports...
 
 type MyBeautifulType = {
-  name: string;
-  age: number;
-};
+  name: string
+  age: number
+}
 
 // rest of the file...
 ```
@@ -1398,9 +1346,9 @@ type MyBeautifulType = {
 // part of the file...
 
 type MyBeautifulType = {
-  name: string;
-  age: number;
-};
+  name: string
+  age: number
+}
 
 // rest of the file...
 ```
@@ -1413,9 +1361,9 @@ Create a type for increase legible
 
 ```ts
 type PersonType = {
-  name: string;
-  age: number;
-  birthDate: string;
+  name: string
+  age: number
+  birthDate: string
 };
 
 const Person = ({ name, age, birthDate }: PersonType) => {
@@ -1431,9 +1379,9 @@ const Person = ({
   age,
   birthDate,
 }: {
-  name: string;
-  age: number;
-  birthDate: string;
+  name: string,
+  age: number,
+  birthDate: string,
 }) => {
   // ...
 };

--- a/README.md
+++ b/README.md
@@ -1050,7 +1050,7 @@ export type SelectProps = TextFieldProps & {
   options: SelectOption[];
 };
 
-const Select: React.FC<SelectProps> = ({ options, ...props }) => {
+const Select = ({ options, ...props }: SelectProps) => {
   return (
     <TextField {...props}>
       {options.map((option) => (
@@ -1078,13 +1078,13 @@ export type SelectProps = {
   onBlur: () => void;
 };
 
-const Select: React.FC<SelectProps> = ({
+const Select = ({
   options,
   disabled,
   onChange,
   value,
   onBlur,
-}) => {
+} : SelectProps) => {
   return (
     <TextField
       disabled={disabled}

--- a/README.md
+++ b/README.md
@@ -1036,7 +1036,7 @@ const MyComponent = (type) => {
 
 ### 7.8 Using spread operator
 
-When creating a component wrapper we can spread the types from our original component. That way the wrapper extends all the props from the original component automatically. Creating a custom type and passing on `React.FC` typescript can give us all the correct props. This is usefull to avoid creating a custom interface for our wrapper with missing props from the original component.
+When creating a component wrapper we can spread the types from our original component. That way the wrapper extends all the props from the original component automatically. Creating a custom type and passing on `React.FC` typescript can give us all the correct props. This is useful to avoid creating a custom interface for our wrapper with missing props from the original component.
 
 **✅ Good:**
 

--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,75 @@ const MyComponent = (type) => {
 }
 ```
 
+### 7.8 Using spread operator
+
+When creating a component wrapper we can spread the types from our original component. That way the wrapper extends all the props from the original component automatically. Creating a custom type and passing on `React.FC` typescript can give us all the correct props. This is usefull to avoid creating a custom interface for our wrapper with missing props from the original component.
+
+**✅ Good:**
+
+```tsx
+import { MenuItem, TextField } from '@mui/material';
+import { TextFieldProps } from '@mui/material';
+
+export type SelectOption = { value: string; label: string };
+
+export type SelectProps = TextFieldProps & {
+  options: SelectOption[];
+};
+
+const Select: React.FC<SelectProps> = ({ options, ...props }) => {
+  return (
+    <TextField {...props}>
+      {options.map((option) => (
+        <MenuItem key={uuidv4()} value={option.value}>
+          {option.label}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+};
+```
+
+**❌ Bad:**
+
+```tsx
+import { MenuItem, TextField } from '@mui/material';
+
+export type SelectOption = { value: string; label: string };
+
+export type SelectProps = {
+  options: SelectOption[];
+  disabled: boolean;
+  onChange: () => void;
+  value: string;
+  onBlur: () => void;
+};
+
+const Select: React.FC<SelectProps> = ({
+  options,
+  disabled,
+  onChange,
+  value,
+  onBlur,
+}) => {
+  return (
+    <TextField
+      disabled={disabled}
+      onChange={handleOnChange}
+      value={value}
+      onBlur={handleOnBlur}
+    >
+      {options.map((option) => (
+        <MenuItem key={uuidv4()} value={option.value}>
+          {option.label}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+};
+```
+
+
 **[⬆ back to summary](#-summary)**
 
 ---


### PR DESCRIPTION
# Add spread operator in react wrapper components with typescript:

### 7.7 Using spread operator

When creating a component wrapper we can spread the types from our original component. That way the wrapper extends all the props from the original component automatically. Creating a custom type and passing on `React.FC` typescript can give us all the correct props. This is usefull to avoid creating a custom interface for our wrapper with missing props from the original component.

**✅ Good:**

```tsx
import { MenuItem, TextField } from '@mui/material';
import { TextFieldProps } from '@mui/material';

export type SelectOption = { value: string; label: string };

export type SelectProps = TextFieldProps & {
  options: SelectOption[];
};

const Select: React.FC<SelectProps> = ({ options, ...props }) => {
  return (
    <TextField {...props}>
      {options.map((option) => (
        <MenuItem key={uuidv4()} value={option.value}>
          {option.label}
        </MenuItem>
      ))}
    </TextField>
  );
};
```

**❌ Bad:**

```tsx
import { MenuItem, TextField } from '@mui/material';

export type SelectOption = { value: string; label: string };

export type SelectProps = {
  options: SelectOption[];
  disabled: boolean;
  onChange: () => void;
  value: string;
  onBlur: () => void;
};

const Select: React.FC<SelectProps> = ({
  options,
  disabled,
  onChange,
  value,
  onBlur,
}) => {
  return (
    <TextField
      disabled={disabled}
      onChange={handleOnChange}
      value={value}
      onBlur={handleOnBlur}
    >
      {options.map((option) => (
        <MenuItem key={uuidv4()} value={option.value}>
          {option.label}
        </MenuItem>
      ))}
    </TextField>
  );
};
```
