### PR TITLE
Remove UUID from key in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1163,7 +1163,7 @@ When creating a component wrapper we can spread the types from our original comp
 import { MenuItem, TextField } from '@mui/material';
 import { TextFieldProps } from '@mui/material';
 
-export type SelectOption = { value: string; label: string };
+export type SelectOption = { value: string; label: string, id: string, };
 
 export type SelectProps = TextFieldProps & {
   options: SelectOption[];
@@ -1173,7 +1173,7 @@ const Select = ({ options, ...props }: SelectProps) => {
   return (
     <TextField {...props}>
       {options.map((option) => (
-        <MenuItem key={uuidv4()} value={option.value}>
+        <MenuItem key={option.id} value={option.value}>
           {option.label}
         </MenuItem>
       ))}
@@ -1187,7 +1187,7 @@ const Select = ({ options, ...props }: SelectProps) => {
 ```tsx
 import { MenuItem, TextField } from '@mui/material';
 
-export type SelectOption = { value: string; label: string };
+export type SelectOption = { value: string; label: string, id: string, };
 
 export type SelectProps = {
   options: SelectOption[];
@@ -1212,7 +1212,7 @@ const Select = ({
       onBlur={handleOnBlur}
     >
       {options.map((option) => (
-        <MenuItem key={uuidv4()} value={option.value}>
+        <MenuItem key={option.id} value={option.value}>
           {option.label}
         </MenuItem>
       ))}


### PR DESCRIPTION
Hi guys, using uuid, math.random() as a key is not a good practice in React. Single-time rendering happens, every component with a key is deleted and remade, causing significant performance issues. As is an example and the intention is not to talk about it, I created an example id type.

References:
https://www.showrin.com/blog/case-study-mistake-with-react-keys-can-kill-the-performance
https://engineering.blackrock.com/5-common-mistakes-with-keys-in-react-b86e82020052