### PR TITLE
docs: Add guidelines for TypeScript Utility Types usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1913,6 +1913,143 @@ export type OrderList = {
 }
 ```
 
+### 11.7 TypeScript Utility Types
+
+`Partial<T>` makes all properties of a type T optional. This is highly useful in front-end scenarios like handling incomplete data from API responses or partially filled forms.
+
+**✅ Good:**
+
+```ts
+type User = {
+  name: string;
+  age: number;
+};
+
+function updateUser(user: Partial<User>) {}
+```
+
+**❌ Bad:**
+
+```ts
+type User = {
+  name?: string;
+  age?: number;
+};
+
+function updateUser(user: User) {}
+```
+
+---
+
+`Readonly<Type>` makes all properties of a type Type read-only, which is useful for creating immutable objects.
+
+**✅ Good:**
+
+```ts
+type User = {
+  name: string;
+  age: number;
+};
+
+const user: Readonly<User> = { name: "Alice", age: 30 };
+```
+
+**❌ Bad:**
+
+```ts
+type User = {
+  name: string;
+  age: number;
+};
+
+const user: User = { name: "Alice", age: 30 };
+user.name = "Bob";
+```
+
+---
+
+`Record<Keys, Type>` creates a type with a set of properties Keys of type Type, ideal for mapping keys to values in an object.
+
+**✅ Good:**
+
+```ts
+type User = { id: number; name: string };
+const userDirectory: Record<number, User> = {
+  1: { id: 1, name: "Alice" },
+};
+```
+
+**❌ Bad:**
+
+```ts
+type User = { id: number; name: string };
+const userDirectory = { 1: { id: 1, name: "Alice" } };
+```
+
+---
+
+`Pick<Type, Keys>` creates a type by picking a set of properties Keys from Type, useful for creating subsets of a type.
+
+**✅ Good:**
+
+```ts
+type User = {
+  id: number;
+  name: string;
+  email: string;
+};
+
+const userSummary: Pick<User, "name" | "email"> = {
+  name: "Alice",
+  email: "alice@example.com",
+};
+```
+
+**❌ Bad:**
+
+```ts
+type User = {
+  id: number;
+  name: string;
+  email: string;
+};
+
+const userSummary = { name: "Alice", email: "alice@example.com" };
+```
+
+---
+
+`Omit<Type, Keys>` creates a type by omitting a set of properties Keys from Type, useful for excluding certain properties from a type.
+
+**✅ Good:**
+
+```ts
+type User = {
+  id: number;
+  name: string;
+  password: string;
+};
+
+const publicUserInfo: Omit<User, "password"> = {
+  id: 1,
+  name: "Alice",
+};
+```
+
+**❌ Bad:**
+
+```ts
+type User = {
+  id: number;
+  name: string;
+  password: string;
+};
+
+const publicUserInfo: User = { id: 1, name: "Alice", password: "secret" };
+```
+
+---
+
 We follow the principle the official [TypeScript doc](https://www.typescriptlang.org/play#example/types-vs-interfaces):
 > _For publicly exposed types, it's a better call to make them an interface._
 


### PR DESCRIPTION
This pull request presents a practical guide on how to use TypeScript's Utility Types effectively. We cover essential types like `Partial<T>`, `Readonly<Type>`, `Record<Keys, Type>`, `Pick<Type, Keys>`, and `Omit<Type, Keys>`, which are fundamental in my day-to-day programming.

They are super useful for improving typing in various situations, from manipulating objects to defining interfaces for components. With them, we achieve fine control over our data, avoiding those annoying typing errors and making our code clearer and easier to maintain.

**References:**
https://www.typescriptlang.org/docs/handbook/utility-types.html