### PR TITLE
docs(readme): clarify commit message subject case requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ In order to facilitate the contribution of anyone in a project, all commit messa
 
 We also use [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/), that is, the commit message must be in the form of a sentence, with the first word being an action, and the rest of the sentence a describing text.
 
-We must always commit in lowercase. We are using a [shared rule to validate this](https://github.com/juntossomosmais/time-out-market/blob/main/packages/linters/src/commitlint.config.js).   
+We must always commit the subject (first word in commit message) in lowercase. We are using a [shared rule to validate this](https://github.com/juntossomosmais/time-out-market/blob/main/packages/linters/src/commitlint.config.js).   
 
 **✅ Good:**
 

--- a/README.md
+++ b/README.md
@@ -341,14 +341,20 @@ In order to facilitate the contribution of anyone in a project, all commit messa
 
 We also use [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/), that is, the commit message must be in the form of a sentence, with the first word being an action, and the rest of the sentence a describing text.
 
-We must always commit the subject (first word in commit message) in lowercase. We are using a [shared rule to validate this](https://github.com/juntossomosmais/time-out-market/blob/main/packages/linters/src/commitlint.config.js).   
+We must always commit in lowercase. If you need to reference a function, code, or other technical term that requires specific casing, please wrap it in backticks (``). This rule is enforced using a [shared configuration](https://github.com/juntossomosmais/time-out-market/blob/main/packages/linters/src/commitlint.config.js).
 
 **✅ Good:**
 
 ```powershell
 git commit -m "feat: allow provided config object to extend configs"
-git commit -m "docs: correct spelling of CHANGELOG"
-git commit -m "feat(lang): add the Portuguese language"
+git commit -m "feat(lang): add the ptbr language"
+```
+
+If you need to reference a function, code, or other technical term that requires specific casing
+
+```powershell
+git commit -m "feat: update `useEffect` rules"
+git commit -m "docs: correct spelling of `CHANGELOG`
 ```
 
 **❌ Bad:**


### PR DESCRIPTION
The original text instructs us to write the commit message in lowercase – which is not true, as one of the examples is "feat(lang): add the Portuguese language" and "docs: correct spelling of CHANGELOG", both of which contain words with uppercase or capital case.

Another fact is that the lowercase validation suggested by the text "We are using a shared rule to validate this." is not for the entire commit message, but only for the subject – the first word of the commit message (feat/fix/docs etc). Check the line: https://github.com/juntossomosmais/time-out-market/blob/7d424f262ef1f991d472c537991fa48e3e3ebe18/packages/linters/src/commitlint.config.js#L20

This leads to misunderstandings and the assumption of a rule that does not exist, opening a loophole for potential errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies commit message lowercase requirement with backtick exceptions for technical terms and updates example commits accordingly.
> 
> - **Docs (README)**:
>   - Clarify commit message lowercase rule and specify wrapping technical terms in backticks for required casing, enforced via shared config.
>   - Update good examples: include backticked `useEffect` and `CHANGELOG`; adjust language example to `feat(lang): add the ptbr language`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 297c4e62fc61d3fd6f9e14353c503302ebe1b6c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->